### PR TITLE
Remove BOM + CRLF from *.cs files

### DIFF
--- a/Toolhouse.Monitoring.Tests/AbstractHandlerTest.cs
+++ b/Toolhouse.Monitoring.Tests/AbstractHandlerTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 using NUnit.Framework;
 

--- a/Toolhouse.Monitoring.Tests/Properties/AssemblyInfo.cs
+++ b/Toolhouse.Monitoring.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/Toolhouse.Monitoring/Handlers/AbstractHttpHandler.cs
+++ b/Toolhouse.Monitoring/Handlers/AbstractHttpHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Configuration;
 using System.Web;
 using System.Security.Cryptography;

--- a/Toolhouse.Monitoring/Handlers/HealthEndpointHandler.cs
+++ b/Toolhouse.Monitoring/Handlers/HealthEndpointHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Web;
 
 namespace Toolhouse.Monitoring.Handlers

--- a/Toolhouse.Monitoring/Handlers/MetricsEndpointHandler.cs
+++ b/Toolhouse.Monitoring/Handlers/MetricsEndpointHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Web;
 
 using Prometheus;

--- a/Toolhouse.Monitoring/Handlers/ReadinessEndpointHandler.cs
+++ b/Toolhouse.Monitoring/Handlers/ReadinessEndpointHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Web;

--- a/Toolhouse.Monitoring/Metrics.cs
+++ b/Toolhouse.Monitoring/Metrics.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Configuration;
 using System.Diagnostics;
 

--- a/Toolhouse.Monitoring/Modules/MetricsModule.cs
+++ b/Toolhouse.Monitoring/Modules/MetricsModule.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Configuration;
 using System.Diagnostics;
 using System.Web;

--- a/Toolhouse.Monitoring/Properties/AssemblyInfo.cs
+++ b/Toolhouse.Monitoring/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/Toolhouse.Monitoring/Readiness.cs
+++ b/Toolhouse.Monitoring/Readiness.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;


### PR DESCRIPTION
Somewhere in all this confusion some .cs files ended up in the repo with Windows line endings and byte order marks. This PR removes them.